### PR TITLE
Updated Permission Request Message

### DIFF
--- a/app/src/main/java/com/rob729/quiethours/Fragments/MainFragment.kt
+++ b/app/src/main/java/com/rob729/quiethours/Fragments/MainFragment.kt
@@ -186,7 +186,7 @@ class MainFragment : Fragment() {
 
         AlertDialog.Builder(context)
             .setTitle("Permission Required")
-            .setMessage("Please give the necessary permissions for the app to work properly.")
+            .setMessage("Please give the Do Not Disturb access permission for the app to work properly. Click OK to continue.")
             .setCancelable(false)
             .setPositiveButton("Ok") { i, dialogInterface ->
                 val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
Fixes #6 

Changes: Changed the permission request message to "Please give the Do Not Disturb access permission for the app to work properly. Click OK to continue."

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/61552810/94563830-dce70b80-0284-11eb-933e-de051831adf8.png" width=270 height=480>