### PR TITLE
Fixed color of AvatarImageView

### DIFF
--- a/app/src/main/java/com/rob729/quiethours/Adapter/ProfileListAdapter.kt
+++ b/app/src/main/java/com/rob729/quiethours/Adapter/ProfileListAdapter.kt
@@ -20,7 +20,6 @@ import com.rob729.quiethours.Database.Profile
 import com.rob729.quiethours.Database.ProfileViewModel
 import com.rob729.quiethours.R
 import com.rob729.quiethours.databinding.ItemRowBinding
-import kotlin.random.Random
 
 class ProfileListAdapter(
     val profileViewModel: ProfileViewModel,
@@ -64,7 +63,7 @@ class ProfileListAdapter(
         fun bind(item: Profile, profileViewModel: ProfileViewModel, parentView: View) {
             binding.ProfileName.text = item.name
             binding.TxtImg.setText(item.name[0].toString())
-            binding.TxtImg.avatarBackgroundColor = bgColors[Random.nextInt(0, 8)]
+            binding.TxtImg.avatarBackgroundColor = bgColors[item.colorIndex]
 
             binding.profileCard.setOnClickListener {
                 val args = Bundle()

--- a/app/src/main/java/com/rob729/quiethours/Database/Profile.kt
+++ b/app/src/main/java/com/rob729/quiethours/Database/Profile.kt
@@ -14,6 +14,8 @@ data class Profile(
     var smin: Int,
     var ehr: Int,
     var emin: Int,
-    var d: String
+    var d: String,
+    // To store profile color in the database
+    var colorIndex: Int
 ) :
     Parcelable

--- a/app/src/main/java/com/rob729/quiethours/Database/ProfileRoomDatabase.kt
+++ b/app/src/main/java/com/rob729/quiethours/Database/ProfileRoomDatabase.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [Profile::class], version = 1)
+@Database(entities = [Profile::class], version = 2)
 abstract class ProfileRoomDatabase : RoomDatabase() {
 
     abstract fun profileDao(): ProfileDAO
@@ -24,9 +26,16 @@ abstract class ProfileRoomDatabase : RoomDatabase() {
                     context.applicationContext,
                     ProfileRoomDatabase::class.java,
                     "Profile_Database"
-                ).build()
+                ).addMigrations(MIGRATION_1_2)
+                    .build()
                 INSTANCE = instance
                 return instance
+            }
+        }
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE profile_table " +
+                        " ADD COLUMN colorIndex INTEGER NOT NULL DEFAULT 3")
             }
         }
     }

--- a/app/src/main/java/com/rob729/quiethours/Fragments/NewProfileFragment.kt
+++ b/app/src/main/java/com/rob729/quiethours/Fragments/NewProfileFragment.kt
@@ -26,6 +26,7 @@ import com.rob729.quiethours.databinding.FragmentNewProfileBinding
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayList
+import kotlin.random.Random
 
 /**
  * A simple [Fragment] subclass.
@@ -130,7 +131,8 @@ class NewProfileFragment : Fragment() {
                     smin = smin,
                     ehr = ehr,
                     emin = emin,
-                    d = daySelected.toJson(days)
+                    d = daySelected.toJson(days),
+                    colorIndex = Random.nextInt(0, 8)
                 )
                 profile.profileId = System.currentTimeMillis()
                 profileViewModel.insert(profile)


### PR DESCRIPTION
Fixes #4 

Changes: Earlier, the color of AvatarImageView used to get changed every time when the view was recreated or the app theme was changed from light mode to dark mode(or vice versa). Now that is fixed.

There is no need to uninstall previous version of app.

Apart from that the data of profiles created earlier doesn't gets affected after the changes.  

Screenshots for the change: 

<table>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/61552810/94763429-d0b79700-03c7-11eb-9119-a67a3c1fd5f3.png" width=270 height=480></td>
    <td><img src="https://user-images.githubusercontent.com/61552810/94763430-d1e8c400-03c7-11eb-9002-ff29e7525cdd.png" width=270 height=480></td>
</tr>
</table>