### PR TITLE
Changed the background color in night mode

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,6 +3,6 @@
     <color name="colorPrimary"> #1565c0  </color>
     <color name="colorPrimaryDark"> #0d47a1 </color>
     <color name="colorAccent"> #1976d2</color>
-    <color name="bgColor">#232323</color>
+    <color name="bgColor">#121212</color>
     <color name="textColor">#fafafa </color>
 </resources>


### PR DESCRIPTION
Fixes #40 

Changes: Changed the background color of MainFragment in night mode to the color same as color of settings in night mode.

Screenshots for the change:

![Screenshot_20201022_185132_com rob729 quiethours 1](https://user-images.githubusercontent.com/56159740/96878177-27306680-1498-11eb-8b3c-14dc493fa450.jpg)



![Screenshot_20201022_185140_com rob729 quiethours 1](https://user-images.githubusercontent.com/56159740/96878290-47f8bc00-1498-11eb-8ade-d67884aa1659.jpg)
