### PR TITLE
Fixed Dark mode bug

### DIFF
--- a/app/src/main/java/com/rob729/quiethours/Activity/MainActivity.kt
+++ b/app/src/main/java/com/rob729/quiethours/Activity/MainActivity.kt
@@ -8,13 +8,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.databinding.DataBindingUtil
 import androidx.navigation.Navigation
-import androidx.preference.PreferenceManager
 import com.rob729.quiethours.R
 import com.rob729.quiethours.databinding.ActivityMainBinding
 import kotlinx.android.synthetic.main.activity_main.*
+import com.rob729.quiethours.util.StoreSession
 
 class MainActivity : AppCompatActivity() {
-
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,8 +22,7 @@ class MainActivity : AppCompatActivity() {
             R.layout.activity_main
         )
         supportActionBar?.elevation = 0F
-        val appSharedPrefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
-        if (appSharedPrefs.getBoolean("nightMode", false)) {
+        if (StoreSession.getNightMode()) {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
         } else {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)

--- a/app/src/main/java/com/rob729/quiethours/Activity/SplashScreen.kt
+++ b/app/src/main/java/com/rob729/quiethours/Activity/SplashScreen.kt
@@ -1,9 +1,12 @@
 package com.rob729.quiethours.Activity
 
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.rob729.quiethours.R
+import com.rob729.quiethours.util.AppConstants
+import com.rob729.quiethours.util.StoreSession
 
 class SplashScreen : AppCompatActivity() {
 
@@ -12,6 +15,13 @@ class SplashScreen : AppCompatActivity() {
         val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)
         overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+        checkFirstRun()
         finish()
+    }
+    fun checkFirstRun() {
+        if (!StoreSession.readBoolean(AppConstants.FIRST_BOOT)) {
+            StoreSession.setNightMode(resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES)
+        }
+        StoreSession.writeBoolean(AppConstants.FIRST_BOOT, true)
     }
 }

--- a/app/src/main/java/com/rob729/quiethours/Fragments/Settings.kt
+++ b/app/src/main/java/com/rob729/quiethours/Fragments/Settings.kt
@@ -17,6 +17,7 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import com.rob729.quiethours.Activity.MainActivity
 import com.rob729.quiethours.R
+import com.rob729.quiethours.util.AppConstants
 
 class Settings : PreferenceFragmentCompat(), SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -27,7 +28,7 @@ class Settings : PreferenceFragmentCompat(), SharedPreferences.OnSharedPreferenc
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.pref_quiet_hours)
-        pref = findPreference("nightMode")
+        pref = findPreference(AppConstants.NIGHT_MODE)
         rate = findPreference("rate")!!
         share = findPreference("share")!!
         format = findPreference("time format")!!

--- a/app/src/main/java/com/rob729/quiethours/util/AppConstants.kt
+++ b/app/src/main/java/com/rob729/quiethours/util/AppConstants.kt
@@ -6,4 +6,6 @@ object AppConstants {
     val VIBRATE_STATE_ICON = "VIBRATE_STATE_ICON"
     val BEGIN_STATUS = "BEGIN_STATUS"
     val PROFILE_ID = "PROFILE_ID"
+    val FIRST_BOOT = "FIRST_BOOT"
+    val NIGHT_MODE = "nightMode"
 }

--- a/app/src/main/java/com/rob729/quiethours/util/StoreSession.kt
+++ b/app/src/main/java/com/rob729/quiethours/util/StoreSession.kt
@@ -2,13 +2,15 @@ package com.rob729.quiethours.util
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
 
 object StoreSession {
     lateinit var sharedPreferences: SharedPreferences
-
+    lateinit var appSharedPrefs: SharedPreferences
     fun init(context: Context) {
         sharedPreferences =
             context.getSharedPreferences(AppConstants.ACTIVE_PROFILE_NAME, Context.MODE_PRIVATE)
+        appSharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
     }
 
     fun writeString(key: String, value: String) {
@@ -28,6 +30,26 @@ object StoreSession {
 
     fun readInt(key: String): Int {
         return sharedPreferences.getInt(key, 0)
+    }
+
+    fun setNightMode(value: Boolean) {
+        val editor = appSharedPrefs.edit()
+        editor?.putBoolean(AppConstants.NIGHT_MODE, value)
+        editor?.apply()
+    }
+
+    fun getNightMode(): Boolean {
+        return appSharedPrefs.getBoolean(AppConstants.NIGHT_MODE, false)
+    }
+
+    fun writeBoolean(key: String, value: Boolean) {
+        val editor = sharedPreferences.edit()
+        editor?.putBoolean(key, value)
+        editor?.apply()
+    }
+
+    fun readBoolean(key: String): Boolean {
+        return sharedPreferences.getBoolean(key, false)
     }
 
     fun writeLong(key: String, value: Long) {


### PR DESCRIPTION
Fixes #45 

Changes:
<ul>
<li>
Created FIRST_BOOT to store boolean value as sharedpreference in order to check app was pre-installed or not.
</li>
<li>
Created IS_DARK to store sharedpreference value as true if the system was set to Dark mode at the time of app installation (or app data reset)</li>
<li>
checkFirstRun() in MainActivity checks whether app is installing for first time or it was pre-installed. It also does the work when app data is reset.</li>
<li>If system dark mode is on at the time of installation, the value of Dark mode in Settings.kt gets set to true.</li>
</ul>

Screenshots:
<table>
<tr>
<td>
<img src = "https://user-images.githubusercontent.com/61552810/97557174-6dd61180-1a00-11eb-81f0-dfa122eed8e6.png" width="200px" height="400px"/>
<img src = "https://user-images.githubusercontent.com/61552810/97557181-70386b80-1a00-11eb-8ffe-e29381726abb.png" width="200px" height="400px"/>
</td>
</tr>
</table>

