### PR TITLE
Replaced Data binding with View Binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,9 @@ android {
     androidExtensions {
         experimental = true
     }
-
-    dataBinding.enabled = true
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/rob729/quiethours/Activity/MainActivity.kt
+++ b/app/src/main/java/com/rob729/quiethours/Activity/MainActivity.kt
@@ -6,21 +6,18 @@ import android.view.View
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.databinding.DataBindingUtil
 import androidx.navigation.Navigation
-import com.rob729.quiethours.R
 import com.rob729.quiethours.databinding.ActivityMainBinding
 import kotlinx.android.synthetic.main.activity_main.*
 import com.rob729.quiethours.util.StoreSession
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityMainBinding
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = DataBindingUtil.setContentView<ActivityMainBinding>(
-            this,
-            R.layout.activity_main
-        )
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         supportActionBar?.elevation = 0F
         if (StoreSession.getNightMode()) {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)

--- a/app/src/main/java/com/rob729/quiethours/Fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/rob729/quiethours/Fragments/DetailsFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment.findNavController
@@ -36,6 +35,9 @@ class DetailsFragment : BottomSheetDialogFragment() {
         }
     }
     private var days: List<Boolean> = ArrayList()
+    private var _binding: FragmentDetailsBinding? = null
+    private val binding
+    get() = _binding!!
 
     @SuppressLint("SetTextI18n")
     override fun onCreateView(
@@ -44,10 +46,7 @@ class DetailsFragment : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        val binding = DataBindingUtil.inflate<FragmentDetailsBinding>(
-            inflater,
-            R.layout.fragment_details, container, false
-        )
+        _binding = FragmentDetailsBinding.inflate(inflater, container, false)
 
         val args = arguments?.getParcelable<Profile>("Profile")
         val daysSelected = Gson()
@@ -94,5 +93,9 @@ class DetailsFragment : BottomSheetDialogFragment() {
         // this forces the sheet to appear at max height even on landscape
         val behavior = BottomSheetBehavior.from(requireView().parent as View)
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
+    }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/rob729/quiethours/Fragments/MainFragment.kt
+++ b/app/src/main/java/com/rob729/quiethours/Fragments/MainFragment.kt
@@ -12,7 +12,6 @@ import android.os.Bundle
 import android.view.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -45,7 +44,6 @@ import com.rob729.quiethours.util.*
  */
 class MainFragment : Fragment() {
     private lateinit var profileViewModel: ProfileViewModel
-    private lateinit var binding: FragmentMainBinding
     lateinit var profileListAdapter: ProfileListAdapter
     private val appUpdateManager: AppUpdateManager by lazy { AppUpdateManagerFactory.create(context) }
     private val appUpdateInfoTask: Task<AppUpdateInfo> by lazy { appUpdateManager.appUpdateInfo }
@@ -53,16 +51,16 @@ class MainFragment : Fragment() {
     val notificationManager =
         context?.getSystemService(NOTIFICATION_SERVICE) as NotificationManager?
     val audioManager by lazy { requireActivity().getSystemService(Context.AUDIO_SERVICE) as AudioManager }
+    private var _binding: FragmentMainBinding? = null
+    private val binding
+    get() = _binding!!
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_main, container, false
-        )
+        _binding = FragmentMainBinding.inflate(inflater, container, false)
         (activity as AppCompatActivity).setSupportActionBar(binding.toolbar)
     checkForUpdates()
 
@@ -75,8 +73,6 @@ class MainFragment : Fragment() {
 
         binding.rv.adapter = profileListAdapter
         binding.rv.layoutManager = LinearLayoutManager(context)
-
-        binding.lifecycleOwner = this
 
         enableSwipeToDeleteAndUndo(profileListAdapter)
 
@@ -296,5 +292,9 @@ class MainFragment : Fragment() {
                 }
             }
         }
+    }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/rob729/quiethours/Fragments/NewProfileFragment.kt
+++ b/app/src/main/java/com/rob729/quiethours/Fragments/NewProfileFragment.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.Navigation
@@ -55,6 +54,9 @@ class NewProfileFragment : Fragment() {
     val selectedDays by lazy { Gson() }
     val type by lazy { object : TypeToken<List<Boolean>>() {}.type }
     val id = StoreSession.readLong(AppConstants.PROFILE_ID)
+    private var _binding: FragmentNewProfileBinding? = null
+    private val binding
+    get() = _binding!!
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -62,10 +64,7 @@ class NewProfileFragment : Fragment() {
     ): View? {
         // Inflate the layout for this fragment
 
-        val binding = DataBindingUtil.inflate<FragmentNewProfileBinding>(
-            inflater,
-            R.layout.fragment_new_profile, container, false
-        )
+        _binding = FragmentNewProfileBinding.inflate(inflater, container, false)
         binding.toolBar.setNavigationOnClickListener { activity!!.onBackPressed() }
         binding.vibSwitch.setOnCheckedChangeListener { buttonView, isChecked ->
             if (isChecked) {
@@ -294,5 +293,9 @@ class NewProfileFragment : Fragment() {
         if (c.timeInMillis < System.currentTimeMillis()) {
             c.add(Calendar.DAY_OF_YEAR, 7)
         }
+    }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
+    <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        tools:context=".Activity.MainActivity">
-    <LinearLayout
-            android:layout_width="match_parent"
+        tools:context=".Activity.MainActivity" android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical">
 
@@ -18,4 +16,3 @@
                 app:navGraph="@navigation/navigation"/>
 
     </LinearLayout>
-</layout>

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
+    <ScrollView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
-        tools:context=".Fragments.DetailsFragment">
-    <ScrollView
+        tools:context=".Fragments.DetailsFragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
     <RelativeLayout
@@ -147,4 +146,3 @@
                 app:fabSize="normal" />
     </RelativeLayout>
     </ScrollView>
-</layout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto"
-        tools:context=".Fragments.MainFragment">
-
     <androidx.coordinatorlayout.widget.CoordinatorLayout
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto"
+            tools:context=".Fragments.MainFragment"
             android:id="@+id/coord_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -138,4 +137,3 @@
                 app:tint="@color/bgColor" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-</layout>

--- a/app/src/main/res/layout/fragment_new_profile.xml
+++ b/app/src/main/res/layout/fragment_new_profile.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
+    <ScrollView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        tools:context=".Fragments.NewProfileFragment">
-    <ScrollView
+        tools:context=".Fragments.NewProfileFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fillViewport="true">
@@ -157,4 +156,3 @@
 
         </RelativeLayout>
     </ScrollView>
-</layout>

--- a/app/src/main/res/layout/item_row.xml
+++ b/app/src/main/res/layout/item_row.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <androidx.cardview.widget.CardView
-            android:id="@+id/card"
+ <androidx.cardview.widget.CardView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
@@ -56,4 +55,3 @@
         </RelativeLayout>
 
     </androidx.cardview.widget.CardView>
-</layout>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.2.0-alpha01"
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 23 22:56:12 IST 2019
+#Thu Nov 05 10:46:41 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Fixes #51 
Changes: Replaced Data Binding with View Binding.

Some changes are also made regarding gradle version because :


"To use View Binding, you need to upgrade to the Android Gradle Plugin version 3.6.0-alpha11 or later. This version of the Android Gradle Plugin requires Gradle 5.6.1 or higher. Also, you need to use Android Studio 3.6 Canary 11+ or newer because older versions of Android Studio won’t open a project that uses the Android Gradle Plugin version 3.6.0-alpha11 or higher."