### PR TITLE
Fixed material day picker cropped layout on narrow screens.

### DIFF
--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -129,12 +129,12 @@
 
         <ca.antonious.materialdaypicker.MaterialDayPicker
                 android:id="@+id/day_picker"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentEnd="true"
                 android:layout_below="@id/col2"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="30dp"
-                android:layout_marginEnd="20dp" />
+                android:layout_marginTop="30dp" />
 
         <View
             android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes #62 

Changes: Fixed material day picker cropped layout on wider screens (ex. 1080p)

Screenshots for the change:

<img src = "https://user-images.githubusercontent.com/56159740/99943889-06f60f00-2d98-11eb-8679-68fe6495a742.jpg" height = "480" width = "250">